### PR TITLE
Fix issue preventing full use of the character set.

### DIFF
--- a/src/create.random.id.js
+++ b/src/create.random.id.js
@@ -28,10 +28,10 @@ export const createRandomId = (length = 32, useUppercaseLetters = true, useLower
    let id = '';
    for (let i = 0; i < length; i++) {
       if (i === 0 && letters.length > 0) {
-         let randomNumber = Math.floor(Math.random() * (letters.length - 1));
+         let randomNumber = Math.floor(Math.random() * (letters.length));
          id += letters[randomNumber];
       } else {
-         let randomNumber = Math.floor(Math.random() * (characters.length - 1));
+         let randomNumber = Math.floor(Math.random() * (characters.length));
          id += characters[randomNumber];
       }
    }

--- a/src/create.random.id.test.js
+++ b/src/create.random.id.test.js
@@ -62,3 +62,13 @@ test('createRandomId(32, true, true, false), it generates a 32-character ID, sta
    expect(!!id.match(/[a-z]/)).toEqual(true);
    expect(!!id.match(/[0-9]/)).toEqual(false);
 });
+
+test('createRandomId(100_000, true, true, false), uses all ten numeric digits at least once', () => {
+   const stats = {};
+   const id = createRandomId(100_000, false, false, true);
+   for (let i = 0; i < id.length; i++) {
+      const ch = id.charAt(i);
+      stats[ch] = (stats[ch] || 0) + 1;
+   }
+   expect(Object.keys(stats)).toHaveLength(10);
+});


### PR DESCRIPTION
Because `Math.random()` always produces a value less than one, the last character in the available set would never be used.
The change itself is straightforward, but the test may be more of an issue. Statistically it's extremely unlikely to produce a false failure with a length of 100,000, but not impossible.